### PR TITLE
:memo: Docs: Installation docs should install as devDependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ MIT License
 ## Install
 
 ```bash
-npm i -S vue-mixin-decorator
+npm install --save-dev vue-mixin-decorator
 ```
 
 ## Usage


### PR DESCRIPTION
- also provide the long-hand version as those who know the shorthand will just use it.