### PR TITLE
fix peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
     "vue-class-component": "^7.1.0"
   },
   "peerDependencies": {
-    "typescript": ">= 2 < 4",
+    "typescript": ">= 2",
     "vue": "^2.5.0"
   },
   "repository": "git+https://github.com/justrhysism/vue-mixin-decorator.git",


### PR DESCRIPTION
Hello, you have a conflict here. You are using version 4, but forgiving to use it.

```
"devDependencies": {
....
"typescript": "^4.0.2",
```
and 
```
"peerDependencies": {
"typescript": ">= 2 < 4",
```